### PR TITLE
password policy and 1-nic fixes #39 fixes #37

### DIFF
--- a/examples/1_nic_with_new_vpc/main.tf
+++ b/examples/1_nic_with_new_vpc/main.tf
@@ -128,7 +128,7 @@ module bigip {
     module.ssh_secure_sg.this_security_group_id,
     module.bigip_mgmt_secure_sg.this_security_group_id
   ]
-  vpc_public_subnet_ids = module.vpc.public_subnets
+  vpc_mgmt_subnet_ids = module.vpc.public_subnets
 }
 
 #

--- a/examples/1_nic_with_new_vpc/main.tf
+++ b/examples/1_nic_with_new_vpc/main.tf
@@ -17,7 +17,7 @@ resource "random_id" "id" {
 resource "random_password" "password" {
   length           = 16
   special          = true
-  override_special = "_%@"
+  override_special = " #%*+,-./:=?@[]^_~"
 }
 
 #
@@ -128,7 +128,7 @@ module bigip {
     module.ssh_secure_sg.this_security_group_id,
     module.bigip_mgmt_secure_sg.this_security_group_id
   ]
-  vpc_mgmt_subnet_ids = module.vpc.public_subnets
+  vpc_public_subnet_ids = module.vpc.public_subnets
 }
 
 #

--- a/examples/2_nic_with_new_vpc/main.tf
+++ b/examples/2_nic_with_new_vpc/main.tf
@@ -15,7 +15,7 @@ resource "random_id" "id" {
 resource "random_password" "password" {
   length           = 16
   special          = true
-  override_special = "_%@"
+  override_special = " #%*+,-./:=?@[]^_~"
 }
 
 #
@@ -127,8 +127,8 @@ module bigip {
     module.web_server_secure_sg.this_security_group_id
   ]
 
-  vpc_public_subnet_ids  = module.vpc.public_subnets
-  vpc_mgmt_subnet_ids    = module.vpc.database_subnets
+  vpc_public_subnet_ids = module.vpc.public_subnets
+  vpc_mgmt_subnet_ids   = module.vpc.database_subnets
 }
 
 #

--- a/examples/3_nic_with_new_vpc/main.tf
+++ b/examples/3_nic_with_new_vpc/main.tf
@@ -15,7 +15,7 @@ resource "random_id" "id" {
 resource "random_password" "password" {
   length           = 16
   special          = true
-  override_special = "_%@"
+  override_special = " #%*+,-./:=?@[]^_~"
 }
 
 #


### PR DESCRIPTION
the 1-nic example passed public subnets to the provisioning module. However, the 1-nic deploy only requires management subnets. the fix uses the public subnets of the vpc for management, in place of the database subnets that are used in the case of the 3-nic example.