### PR TITLE
Multiple public ips closes #46

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -40,9 +40,10 @@ resource "aws_eip" "mgmt" {
 # Create Public Network Interfaces
 #
 resource "aws_network_interface" "public" {
-  count           = length(var.vpc_public_subnet_ids)
-  subnet_id       = var.vpc_public_subnet_ids[count.index]
-  security_groups = var.public_subnet_security_group_ids
+  count             = length(var.vpc_public_subnet_ids)
+  subnet_id         = var.vpc_public_subnet_ids[count.index]
+  security_groups   = var.public_subnet_security_group_ids
+  private_ips_count = var.application_endpoint_count
 }
 
 # 

--- a/main.tf
+++ b/main.tf
@@ -43,6 +43,7 @@ resource "aws_network_interface" "public" {
   count             = length(var.vpc_public_subnet_ids)
   subnet_id         = var.vpc_public_subnet_ids[count.index]
   security_groups   = var.public_subnet_security_group_ids
+  private_ips_count = var.application_endpoint_count
 }
 
 # 

--- a/main.tf
+++ b/main.tf
@@ -43,7 +43,6 @@ resource "aws_network_interface" "public" {
   count             = length(var.vpc_public_subnet_ids)
   subnet_id         = var.vpc_public_subnet_ids[count.index]
   security_groups   = var.public_subnet_security_group_ids
-  private_ips_count = var.application_endpoint_count
 }
 
 # 

--- a/outputs.tf
+++ b/outputs.tf
@@ -21,3 +21,18 @@ output "public_nic_ids" {
   description = "List of BIG-IP public network interface ids"
   value       = aws_network_interface.public[*].id
 }
+
+output "mgmt_addresses" {
+  description = "List of BIG-IP management addresses"
+  value       = aws_network_interface.mgmt[*].private_ips
+}
+
+output "public_addresses" {
+  description = "List of BIG-IP public addresses"
+  value       = aws_network_interface.public[*].private_ips
+}
+
+output "private_addresses" {
+  description = "List of BIG-IP private addresses"
+  value       = aws_network_interface.private[*].private_ips
+}

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,12 @@ variable "f5_ami_search_name" {
   default     = "F5 Networks BIGIP-14.* PAYG - Best 200Mbps*"
 }
 
+variable "application_endpoint_count" {
+  description = "number of public application addresses to assign"
+  type        = number
+  default     = 5
+}
+
 variable "f5_instance_count" {
   description = "Number of BIG-IPs to deploy"
   type        = number

--- a/variables.tf
+++ b/variables.tf
@@ -10,12 +10,6 @@ variable "f5_ami_search_name" {
   default     = "F5 Networks BIGIP-14.* PAYG - Best 200Mbps*"
 }
 
-variable "application_endpoint_count" {
-  description = "number of public application addresses to assign"
-  type        = number
-  default     = 5
-}
-
 variable "f5_instance_count" {
   description = "Number of BIG-IPs to deploy"
   type        = number

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,12 @@ variable "f5_instance_count" {
   default     = 1
 }
 
+variable "application_endpoint_count" {
+  description = "number of public application addresses to assign"
+  type        = number
+  default     = 5
+}
+
 variable "ec2_instance_type" {
   description = "AWS EC2 instance type"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -19,7 +19,7 @@ variable "f5_instance_count" {
 variable "application_endpoint_count" {
   description = "number of public application addresses to assign"
   type        = number
-  default     = 5
+  default     = 2
 }
 
 variable "ec2_instance_type" {


### PR DESCRIPTION
the intent of this is to provide a mechanism for allocating public ips that would be assigned as application destinations. And, also to output the ip addresses in an easy to consume fashion.