### PR TITLE
add option for custom user data

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -129,7 +129,7 @@ resource "aws_instance" "f5_bigip" {
   }
 
   # build user_data file from template
-  user_data = templatefile(
+  user_data = var.custom_user_data != null ? var.custom_user_data : templatefile(
     "${path.module}/f5_onboard.tmpl",
     {
       DO_URL      = var.DO_URL,

--- a/variables.tf
+++ b/variables.tf
@@ -87,3 +87,9 @@ variable iam_instance_profile {
   description = "IAM Profile used by the BIG-IP for access to secrets manager, S3, EC2 and Logging"
   type        = string
 }
+
+variable custom_user_data {
+  description = "Provide a custom bash script or cloud-init script the BIG-IP will run on creation"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
Add option to supply a custom bash or cloud-init script to the BIG-IP ec2 instance
fixes [AB#40129](https://dev.azure.com/f5eng/1969f822-cce2-4965-baeb-b0253d28034f/_workitems/edit/40129)