### PR TITLE
include CVE-2020-5902 workaround

### DIFF
--- a/f5_onboard.tmpl
+++ b/f5_onboard.tmpl
@@ -6,7 +6,7 @@ tmsh modify sys httpd include '"
 FileETag MTime Size
 
 # CVE-2020-5902
-<LocationMatch "\"".*\.\.;.*"\"">
+<LocationMatch ";">
 	Redirect 404 /
 </LocationMatch>"'
 tmsh save sys config

--- a/f5_onboard.tmpl
+++ b/f5_onboard.tmpl
@@ -1,5 +1,18 @@
 #!/bin/bash
 
+# CVE-2020-5902
+tmsh modify sys httpd include '"
+# File ETAG CVE
+FileETag MTime Size
+
+# CVE-2020-5902
+<LocationMatch "\"".*\.\.;.*"\"">
+	Redirect 404 /
+</LocationMatch>"'
+tmsh save sys config
+bigstart restart httpd
+# /CVE-2020-5902
+
 # Script must be non-blocking or run in the background.
 
 mkdir -p /config/cloud


### PR DESCRIPTION
this PR is to fix the branch used by SCA v2