### PR TITLE
Fix deprecated expressions error

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ data "aws_ami" "f5_ami" {
 
   filter {
     name   = "name"
-    values = ["${var.f5_ami_search_name}"]
+    values = [var.f5_ami_search_name]
   }
 }
 


### PR DESCRIPTION
Warning: Interpolation-only expressions are deprecated

  on .terraform/modules/bigip/main.tf line 17, in data "aws_ami" "f5_ami":
  17:     values = ["${var.f5_ami_search_name}"]

Terraform 0.11 and earlier required all non-constant expressions to be
provided via interpolation syntax, but this pattern is now deprecated. To
silence this warning, remove the "${ sequence from the start and the }"
sequence from the end of this expression, leaving just the inner expression.